### PR TITLE
Add hrm

### DIFF
--- a/libAnt/drivers/serial.py
+++ b/libAnt/drivers/serial.py
@@ -29,7 +29,7 @@ class SerialDriver(Driver):
 
     def _open(self) -> None:
         try:
-            self._serial = Serial(port=self._device, baudrate=self._baudRate)
+            self._serial = Serial(port=self._device, baudrate=self._baudRate, dsrdtr=True, rtscts=True)
         except SerialException as e:
             raise DriverException(str(e))
 

--- a/libAnt/drivers/serial.py
+++ b/libAnt/drivers/serial.py
@@ -29,7 +29,7 @@ class SerialDriver(Driver):
 
     def _open(self) -> None:
         try:
-            self._serial = Serial(port=self._device, baudrate=self._baudRate, dsrdtr=True, rtscts=True)
+            self._serial = Serial(port=self._device, baudrate=self._baudRate)
         except SerialException as e:
             raise DriverException(str(e))
 

--- a/libAnt/profiles/factory.py
+++ b/libAnt/profiles/factory.py
@@ -3,10 +3,12 @@ from threading import Lock
 from libAnt.message import BroadcastMessage
 from libAnt.profiles.power_profile import PowerProfileMessage
 from libAnt.profiles.speed_cadence_profile import SpeedAndCadenceProfileMessage
+from libAnt.profiles.heartrate_profile import HeartRateProfileMessage
 
 
 class Factory:
     types = {
+        120: HeartRateProfileMessage,
         121: SpeedAndCadenceProfileMessage,
         11: PowerProfileMessage
     }

--- a/libAnt/profiles/heartrate_profile.py
+++ b/libAnt/profiles/heartrate_profile.py
@@ -1,0 +1,22 @@
+from libAnt.core import lazyproperty
+from libAnt.profiles.profile import ProfileMessage
+
+
+class HeartRateProfileMessage(ProfileMessage):
+    """ Message from Heart Rate Monitor """
+
+    def __init__(self, msg, previous):
+        super().__init__(msg, previous)
+
+    def __str__(self):
+        return f'{self.heartrate}'
+
+    @lazyproperty
+    def heartrate(self):
+        """ 
+            Instantaneous heart rate. This value is
+            intended to be displayed by the display
+            device without further interpretation.
+            If Invalid set to 0x00 
+        """
+        return self.msg.content[7]


### PR DESCRIPTION
Adds the ability to read a heart rate sensor Computed Heart Rate. 

```
pi@raspberrypi:~/libant/demos $ sudo python3 04-serial-driver.py                                        
61
61
61
61
60
60
...
```

Also works around PySerial 3.1 issue per their recommendation: https://github.com/pyserial/pyserial/issues/139